### PR TITLE
Add a mapfooter skeleton

### DIFF
--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -11,6 +11,8 @@ Ext.define('CpsiMapview.view.main.Map', {
         'CpsiMapview.model.button.MeasureButton',
         'CpsiMapview.controller.button.MeasureButtonController',
 
+        'CpsiMapview.view.toolbar.MapFooter',
+
         'BasiGX.view.button.Measure',
         'BasiGX.view.button.ZoomToExtent'
     ],
@@ -47,11 +49,8 @@ Ext.define('CpsiMapview.view.main.Map', {
             }
         }]
     }, {
-        xtype: 'toolbar',
-        dock: 'bottom',
-        items: [{
-            text: 'Docked to the bottom'
-        }]
+        xtype: 'cmv_mapfooter',
+        dock: 'bottom'
     }],
 
     items: [{

--- a/app/view/toolbar/MapFooter.js
+++ b/app/view/toolbar/MapFooter.js
@@ -1,0 +1,17 @@
+/**
+ * A basic toolbar which serves as a container for other components.
+ */
+Ext.define('CpsiMapview.view.toolbar.MapFooter', {
+    extend: 'Ext.toolbar.Toolbar',
+    xtype: 'cmv_mapfooter',
+
+    requires: [
+        'BasiGX.view.combo.ScaleCombo'
+    ],
+
+    items: [
+        {
+            xtype: 'basigx-combo-scale'
+        }
+    ]
+});


### PR DESCRIPTION
This adds a very basic map footer component which holds a resolution combo for now.

This combo shows an odd behaviour on first rendering, the prefix `1 :` is missing, upon zoom changes in the map it updates fine and displays correctly. I'll open a ticket for this, and think this shouldn't block this from being merged.

Fixes #17 