### PR TITLE
Use Ext.GlobalEvents for component-independent events

### DIFF
--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -31,7 +31,7 @@ Ext.define('CpsiMapview.view.LayerTree', {
         if (map) {
             cfg.store = me.makeLayerStore(map);
         } else {
-            CpsiMapview.getApplication().on('mapready', me.autoConnectToMap);
+            Ext.GlobalEvents.on('cmv-mapready', me.autoConnectToMap);
         }
         me.callParent([cfg]);
     },

--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -67,6 +67,6 @@ Ext.define('CpsiMapview.view.main.Map', {
         me.mapCmp = me.down('gx_map');
         me.olMap = me.mapCmp.map;
 
-        CpsiMapview.getApplication().fireEvent('mapready', me);
+        Ext.GlobalEvents.fireEvent('cmv-mapready', me);
     }
 });


### PR DESCRIPTION
Use `Ext.GlobalEvents` for component-independent (global) event handling instead of letting the root-application managing this.
Background is the missing application-object, when `CpsiMapview` is used as library.