### PR TITLE
 Custom Tooltips for Vector Layers

### DIFF
--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -204,10 +204,6 @@ Ext.define('CpsiMapview.factory.Layer', {
 
             // show / hide on appropriate events
             mapPanel.on('cmv-map-pointerrest', function(hoveredObjs, evt) {
-                // hide if no feature was hit on pointerrest
-                if (hoveredObjs.length === 0) {
-                    toolTip.hide();
-                }
                 // show tooltip with feature attribute information
                 Ext.each(hoveredObjs, function (hoveredObj) {
                     if (hoveredObj.layer &&
@@ -218,8 +214,14 @@ Ext.define('CpsiMapview.factory.Layer', {
                 });
             });
 
-            mapPanel.on('cmv-map-pointerrestout', function () {
+            // hide tooltip if mouse moves again
+            mapPanel.on('cmv-map-pointermove', function () {
                 toolTip.hide();
+            });
+
+            // hide all tooltips if cursor leaves map
+            mapPanel.on('cmv-map-pointerrestout', function () {
+                CpsiMapview.view.layer.ToolTip.clear();
             });
         }
 

--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -210,7 +210,9 @@ Ext.define('CpsiMapview.factory.Layer', {
                 }
                 // show tooltip with feature attribute information
                 Ext.each(hoveredObjs, function (hoveredObj) {
-                    if (hoveredObj.layer.toolTip) {
+                    if (hoveredObj.layer &&
+                          hoveredObj.layer.id === wfsLayer.id &&
+                          hoveredObj.layer.toolTip) {
                         hoveredObj.layer.toolTip.draw(hoveredObj.feature, evt);
                     }
                 });

--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -190,12 +190,34 @@ Ext.define('CpsiMapview.factory.Layer', {
             visible: layerConf.openLayers.visibility,
             minResolution: layerConf.openLayers.minResolution,
             maxResolution: layerConf.openLayers.maxResolution,
-            opacity: layerConf.openLayers.opacity
+            opacity: layerConf.openLayers.opacity,
+            toolTipConfig: layerConf.tooltipsConfig
         });
 
         if (layerConf.tooltipsConfig) {
-            //TODO has to be implemented with
-            //     https://github.com/meggsimum/cpsi-mapview/issues/27
+            // create a custom toolitp for this layer
+            var toolTip = Ext.create('CpsiMapview.view.layer.ToolTip', {
+                toolTipConfig: layerConf.tooltipsConfig
+            });
+            wfsLayer.toolTip = toolTip;
+
+            // show / hide on appropriate events
+            mapPanel.on('cmv-map-pointerrest', function(hoveredObjs, evt) {
+                // hide if no feature was hit on pointerrest
+                if (hoveredObjs.length === 0) {
+                    toolTip.hide();
+                }
+                // show tooltip with feature attribute information
+                Ext.each(hoveredObjs, function (hoveredObj) {
+                    if (hoveredObj.layer.toolTip) {
+                        hoveredObj.layer.toolTip.draw(hoveredObj.feature, evt);
+                    }
+                });
+            });
+
+            mapPanel.on('cmv-map-pointerrestout', function () {
+                toolTip.hide();
+            });
         }
 
         return wfsLayer;

--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -197,7 +197,8 @@ Ext.define('CpsiMapview.factory.Layer', {
         if (layerConf.tooltipsConfig) {
             // create a custom toolitp for this layer
             var toolTip = Ext.create('CpsiMapview.view.layer.ToolTip', {
-                toolTipConfig: layerConf.tooltipsConfig
+                toolTipConfig: layerConf.tooltipsConfig,
+                layer: wfsLayer
             });
             wfsLayer.toolTip = toolTip;
 

--- a/app/view/layer/ToolTip.js
+++ b/app/view/layer/ToolTip.js
@@ -35,8 +35,18 @@ Ext.define('CpsiMapview.view.layer.ToolTip', {
      */
     draw: function (feature, evt) {
         var me = this;
+        var featureCluster = feature.getProperties().features;
 
-        //TODO care about clustered features
+        // care about clustered features
+        if (featureCluster) {
+            // in this case take the first feature in the cluster to define the
+            // tooltop text
+            if (featureCluster.length > 0) {
+                feature = featureCluster[0];
+            } else {
+                Ext.log.error('No cluster features found');
+            }
+        }
 
         //TODO check for layer's formatFunction
         var html = me.formatFunction(feature);

--- a/app/view/layer/ToolTip.js
+++ b/app/view/layer/ToolTip.js
@@ -14,8 +14,17 @@ Ext.define('CpsiMapview.view.layer.ToolTip', {
     /** @cfg The offset from the event's mouse y-position */
     offsetY: 10,
 
-    /** @cfg The config object for this tooltip instance */
+    /**
+     * The tooltip configuration from the layer JSON-configuration
+     * @cfg {Object}
+     */
     toolTipConfig: null,
+
+    /**
+     * Layer refrence for which this tooltip shows the content
+     * @cfg {ol.layer.Base}
+     */
+    layer: null,
 
     /**
      * @private
@@ -48,8 +57,16 @@ Ext.define('CpsiMapview.view.layer.ToolTip', {
             }
         }
 
-        //TODO check for layer's formatFunction
-        var html = me.formatFunction(feature);
+        // check for layer's formatFunction
+        var html;
+        if (me.layer && Ext.isFunction(me.layer.formatFunction)) {
+            // the layer has its own formatFunction, do not use the default one
+            html = me.layer.formatFunction(feature);
+        } else {
+            html = me.formatFunction(feature);
+        }
+
+        // set HTML content
         me.setHtml(html);
 
         // show tooltip near mouse pointer

--- a/app/view/layer/ToolTip.js
+++ b/app/view/layer/ToolTip.js
@@ -50,6 +50,18 @@ Ext.define('CpsiMapview.view.layer.ToolTip', {
      */
     opacity: null,
 
+    statics: {
+        /**
+         * Hides all layer tooltips.
+         */
+        clear: function () {
+            var ttips = Ext.ComponentQuery.query('cmv_layer_tooltip');
+            Ext.each(ttips, function (tip) {
+                tip.hide();
+            });
+        }
+    },
+
     /**
      * @private
      */

--- a/app/view/layer/ToolTip.js
+++ b/app/view/layer/ToolTip.js
@@ -1,0 +1,79 @@
+/**
+ * Mouse tooltip for a vector layer to show layer/feature information on the
+ * map. For example show attributes when feature gets hovered with the mouse.
+ */
+Ext.define('CpsiMapview.view.layer.ToolTip', {
+    extend: 'Ext.tip.Tip',
+    xtype: 'cmv_layer_tooltip',
+    requires: [
+    ],
+
+    /** @cfg The offset from the event's mouse x-position */
+    offsetX: 10,
+
+    /** @cfg The offset from the event's mouse y-position */
+    offsetY: 10,
+
+    /** @cfg The config object for this tooltip instance */
+    toolTipConfig: null,
+
+    /**
+     * @private
+     */
+    initComponent: function () {
+        var me = this;
+
+        me.callParent();
+    },
+
+    /**
+     * Draws a tooltip at the given event position.
+     * The content is derived from the #formatFunction.
+     *
+     * @param {ol.Feature} feature The feature to draw the tooltip for
+     * @param {ol.MapBrowserEvent} evt The MapBrowserEvent event of OpenLayers
+     */
+    draw: function (feature, evt) {
+        var me = this;
+
+        //TODO care about clustered features
+
+        //TODO check for layer's formatFunction
+        var html = me.formatFunction(feature);
+        me.setHtml(html);
+
+        // show tooltip near mouse pointer
+        var screenX = evt.originalEvent.x +  me.offsetX;
+        var screenY = evt.originalEvent.y + me.offsetY;
+        me.showAt([screenX, screenY]);
+    },
+
+    /**
+     * Tranforms the feature's attributes to the wanted HTML structure shown in
+     * this tooltip.
+     * This function can be overridden if different HTML is needed for a custom
+     * layer.
+     * @param  {ol.Feature} feature The feature to get the HTML for
+     * @return {String}             HTML code as text
+     */
+    formatFunction: function (feature) {
+        var me = this;
+        var htmlParts = [];
+
+        Ext.each(me.toolTipConfig, function (tipConf) {
+            var key = tipConf.alias || tipConf.property;
+            var value = feature.get(tipConf.property);
+            if (String(value) === '-999') {
+                // HACK
+                // -999 is the default value used for NULLs so WFS layers can
+                // work with MapInfo as TAB files don't allow NULL values
+                value = null;
+            }
+
+            var htmlPart = Ext.String.format('<b>{0}: </b>{1}', key, value);
+            htmlParts.push(htmlPart);
+        });
+
+        return htmlParts.join('<br/>');
+    }
+});

--- a/app/view/layer/ToolTip.js
+++ b/app/view/layer/ToolTip.js
@@ -27,12 +27,47 @@ Ext.define('CpsiMapview.view.layer.ToolTip', {
     layer: null,
 
     /**
+     * Custom background color of this tooltip
+     * @type {String} Color
+     */
+    bgColor: null,
+
+    /**
+     * Custom text color of this tooltip
+     * @type {String} Color
+     */
+    textColor: null,
+
+    /**
+     * Custom bold font weight of this tooltip
+     * @type {Boolean} true=bold
+     */
+    bold: false,
+
+    /**
+     * Custom background opacity of this tooltip
+     * @type {Number} Opacity between 0 and 1
+     */
+    opacity: null,
+
+    /**
      * @private
      */
     initComponent: function () {
         var me = this;
 
         me.callParent();
+
+        // adjust style with custom values
+        me.on('afterrender', function () {
+            var domEl = me.getEl();
+            domEl.applyStyles({
+                backgroundColor: me.bgColor,
+                color: me.textColor,
+                fontWeight: me.bold ? 'bold' : null
+            });
+            domEl.setOpacity(me.opacity);
+        });
     },
 
     /**

--- a/app/view/layer/ToolTip.js
+++ b/app/view/layer/ToolTip.js
@@ -117,7 +117,7 @@ Ext.define('CpsiMapview.view.layer.ToolTip', {
         me.setHtml(html);
 
         // show tooltip near mouse pointer
-        var screenX = evt.originalEvent.x +  me.offsetX;
+        var screenX = evt.originalEvent.x + me.offsetX;
         var screenY = evt.originalEvent.y + me.offsetY;
         me.showAt([screenX, screenY]);
     },

--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -30,6 +30,8 @@ Ext.define('CpsiMapview.view.main.Map', {
 
     items: [{
         xtype: 'gx_map',
+        pointerRest: true,
+        pointerRestInterval: 500,
         map: new ol.Map({
             // layers will be created from config in initComponent
             layers: [],
@@ -49,13 +51,20 @@ Ext.define('CpsiMapview.view.main.Map', {
     enableMapClick: true,
 
     /**
+     * Enables a 'pointerrest' handler on the map which fires an event
+     * 'cmv-map-pointerrest' with all hovered vector features and their
+     * corresponding layers.
+     * @config {Boolean}
+     */
+    enableMapHover: true,
+
+    /**
      * @event cmv-mapclick
      * Fires when the OL map is clicked.
      * @param {CpsiMapview.view.main.Map} this
      * @param {Object[]} clickInfo The clicked features and the corresponding layers, like `[{feature: aFeat, layer: aLayer}, ...]`
      * @param {ol.MapBrowserEvent)} evt The original 'singleclick' event of OpenLayers
      */
-
 
     inheritableStatics: {
         /**
@@ -107,6 +116,25 @@ Ext.define('CpsiMapview.view.main.Map', {
 
                 // fire event to forward click info to subscribers
                 me.fireEvent('cmv-mapclick', clickedFeatures, evt);
+            });
+        }
+
+        if (me.enableMapHover) {
+            me.mapCmp.on('pointerrest', function(evt) {
+                var hoveredFeatures = [];
+                me.olMap.forEachFeatureAtPixel(evt.pixel,
+                    function(feature, layer) {
+                        // collect all clicked features and their layers
+                        hoveredFeatures.push({feature: feature, layer: layer});
+                    }
+                );
+
+                // fire event to forward hover info to subscribers
+                me.fireEvent('cmv-map-pointerrest', hoveredFeatures, evt);
+            });
+
+            me.mapCmp.on('pointerrestout', function () {
+                me.fireEvent('cmv-map-pointerrestout');
             });
         }
 

--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -170,6 +170,10 @@ Ext.define('CpsiMapview.view.main.Map', {
             me.mapCmp.on('pointerrestout', function () {
                 me.fireEvent('cmv-map-pointerrestout');
             });
+
+            me.olMap.on('pointermove', function () {
+                me.fireEvent('cmv-map-pointermove');
+            });
         }
 
         Ext.GlobalEvents.fireEvent('cmv-mapready', me);

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -68,7 +68,7 @@
     "url": "http://ows.terrestris.de/geoserver/osm/wfs",
     "featureType": "osm:osm-fuel",
     "serverOptions": {},
-    "noCluster": true,
+    "noCluster": false,
     "tooltipsConfig": [
         {
             "property": "id"

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -68,6 +68,23 @@
     "url": "http://ows.terrestris.de/geoserver/osm/wfs",
     "featureType": "osm:osm-fuel",
     "serverOptions": {},
+    "noCluster": true,
+    "tooltipsConfig": [
+        {
+            "property": "id"
+        },
+        {
+            "alias": "Name",
+            "property": "name"
+        },
+        {
+            "alias": "OSM ID",
+            "property": "osm_id"
+        },
+        {
+            "property": "type"
+        }
+    ],
     "openLayers": {
       "maxResolution": 1222.99245234375,
       "numZoomLevels": 12,


### PR DESCRIPTION
This adds custom tooltips for hovered vector features on the map. The tooltips can be enabled if the corresponding layer has the property `tooltipsConfig` in its JSON-configuration:

![grafik](https://user-images.githubusercontent.com/1185547/48426438-15e86680-e767-11e8-87e4-4d46d11b7bb3.png)

Closes #27.