### PR TITLE
Measure tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ bootstrap.json
 bootstrap.jsonp
 
 package-lock.json
+
+# VSCode workspace
+*.code-workspace

--- a/app/controller/button/MeasureButton.js
+++ b/app/controller/button/MeasureButton.js
@@ -1,5 +1,5 @@
 /**
- * This class is the controller for the measure buttons for the application. *
+ * This class is the controller for the measure buttons for the application.
  */
 Ext.define('CpsiMapview.controller.button.MeasureButtonController', {
     extend: 'Ext.app.ViewController',

--- a/app/controller/button/MeasureButton.js
+++ b/app/controller/button/MeasureButton.js
@@ -1,0 +1,8 @@
+/**
+ * This class is the controller for the measure buttons for the application. *
+ */
+Ext.define('CpsiMapview.controller.button.MeasureButtonController', {
+    extend: 'Ext.app.ViewController',
+
+    alias: 'controller.cmv_btn_measure'
+});

--- a/app/model/button/MeasureButton.js
+++ b/app/model/button/MeasureButton.js
@@ -1,0 +1,20 @@
+/**
+ * This class is the view model for the Main view of the application.
+ */
+Ext.define('CpsiMapview.model.button.MeasureButton', {
+    extend: 'Ext.app.ViewModel',
+
+    alias: 'viewmodel.cmw_btn_measure',
+
+    data: {
+        measureTooltext: null, // don't show text
+        lineMeasureTooltip: 'Measure a distance',
+        polygonMeasureAreaTooltip: 'Measure an area',
+        textline: 'Measure distance',
+        textpoly: 'Measure area',
+        tooltipLine: 'Measure distance',
+        tooltipPoly: 'Measure area',
+        continuePolygonMsg: 'Click to measure a distance',
+        continueLineMsg: 'Click to measure an area'
+    }
+});

--- a/app/model/button/MeasureButton.js
+++ b/app/model/button/MeasureButton.js
@@ -9,12 +9,12 @@ Ext.define('CpsiMapview.model.button.MeasureButton', {
     data: {
         measureTooltext: null, // don't show text
         lineMeasureTooltip: 'Measure a distance',
-        polygonMeasureAreaTooltip: 'Measure an area',
         textline: 'Measure distance',
-        textpoly: 'Measure area',
         tooltipLine: 'Measure distance',
+        continueLineMsg: 'Click to measure a distance',
+        textpoly: 'Measure area',
         tooltipPoly: 'Measure area',
-        continuePolygonMsg: 'Click to measure a distance',
-        continueLineMsg: 'Click to measure an area'
+        polygonMeasureAreaTooltip: 'Measure an area',
+        continuePolygonMsg: 'Click to measure an area'
     }
 });

--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -8,6 +8,10 @@ Ext.define('CpsiMapview.view.main.Map', {
     requires: [
         'GeoExt.component.Map',
 
+        'CpsiMapview.model.button.MeasureButton',
+        'CpsiMapview.controller.button.MeasureButtonController',
+
+        'BasiGX.view.button.Measure',
         'BasiGX.view.button.ZoomToExtent'
     ],
 
@@ -19,6 +23,39 @@ Ext.define('CpsiMapview.view.main.Map', {
         items: [{
             xtype: 'basigx-button-zoomtoextent',
             extent: [-1210762, 6688545, -600489, 7490828]
+        }, {
+            xtype: 'basigx-button-measure',
+            measureType: 'line',
+            toggleGroup: 'measure-tools',
+            viewModel: 'cmw_btn_measure',
+            controller: 'cmv_btn_measure',
+            glyph: 'xf068@FontAwesome',
+            listeners: {
+                afterrender: function (btn) {
+                    btn.setBind({
+                        text: '{measureTooltext}',
+                        tooltip: '{lineMeasureTooltip}'
+                    });
+                    btn.tooltipStr = this.lookupViewModel().get('lineMeasureTooltip');
+                }
+            }
+        }, {
+            xtype: 'basigx-button-measure',
+            measureType: 'polygon',
+            toggleGroup: 'measure-tools',
+            glyph: 'xf044@FontAwesome',
+            viewModel: 'cmw_btn_measure',
+            controller: 'cmv_btn_measure',
+            enableToggle: true,
+            listeners: {
+                afterrender: function (btn) {
+                    btn.setBind({
+                        text: '{measureTooltext}',
+                        tooltip: '{polygonMeasureAreaTooltip}'
+                    });
+                    btn.tooltipStr = this.lookupViewModel().get('polygonMeasureAreaTooltip');
+                }
+            }
         }]
     }, {
         xtype: 'toolbar',

--- a/sass/src/view/main/Map.scss
+++ b/sass/src/view/main/Map.scss
@@ -1,0 +1,6 @@
+.basigx-measure-tooltip {
+  font-weight: bold;
+  text-shadow: 0 0 5px white;
+  -moz-text-shadow: 0 0 5px white;
+  -webkit-text-shadow: 0 0 5px white;
+}


### PR DESCRIPTION
This PR adds BasiGX measure tools to to header toolbar of cpsi-mapview.

Currently the following (Font Awesome) icons are used for buttons:
![image](https://user-images.githubusercontent.com/10559603/48349058-67b7c080-e683-11e8-800a-2c6cc7ef7390.png)

