### PR TITLE
Include zoom buttons

### DIFF
--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -14,6 +14,8 @@ Ext.define('CpsiMapview.view.main.Map', {
         'CpsiMapview.view.toolbar.MapFooter',
 
         'BasiGX.view.button.Measure',
+        'BasiGX.view.button.ZoomIn',
+        'BasiGX.view.button.ZoomOut',
         'BasiGX.view.button.ZoomToExtent',
         'BasiGX.util.Projection'
     ],
@@ -28,6 +30,10 @@ Ext.define('CpsiMapview.view.main.Map', {
         items: [{
             xtype: 'basigx-button-zoomtoextent',
             extent: [-1210762, 6688545, -600489, 7490828]
+        }, {
+            xtype: 'basigx-button-zoomin'
+        }, {
+            xtype: 'basigx-button-zoomout'
         }, {
             xtype: 'basigx-button-measure',
             measureType: 'line',


### PR DESCRIPTION
This includes a zoom in and out button, that both react on a single click and either zoom in or out.

See #18. 

@geographika Is this what was envisioned in #18?

We opted out of rectangle zoom-in and out AFAICT

![zoom2](https://user-images.githubusercontent.com/227934/48535956-56ea9300-e8ad-11e8-9133-bca18435460d.gif)

