### PR TITLE
Add map permalink functionality

### DIFF
--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -109,6 +109,13 @@ Ext.define('CpsiMapview.view.main.Map', {
     shouldUpdatePermalink: true,
 
     /**
+     * Flag to steer if center coordinates in the permalink should be rounded or
+     * not
+     * @config {Boolean}
+     */
+    roundPermalinkCoords: true,
+
+    /**
      * @event cmv-mapclick
      * Fires when the OL map is clicked.
      * @param {CpsiMapview.view.main.Map} this
@@ -302,11 +309,24 @@ Ext.define('CpsiMapview.view.main.Map', {
             me.shouldUpdatePermalink = true;
             return;
         }
+
         var mapState = me.getState();
+
+        // check if we have to round the coords (if no coordinates in deegrees)
+        var doRound =
+            me.roundPermalinkCoords &&
+            me.olMap.getView().getProjection().getUnits() !== 'degrees';
+        var centerX = mapState.center[0];
+        var centerY = mapState.center[1];
+        if (doRound) {
+            centerX = Math.round(centerX * 100) / 100;
+            centerY = Math.round(centerY * 100) / 100;
+        }
+
         var hash = '#map=' +
             mapState.zoom + '/' +
-            Math.round(mapState.center[0] * 100) / 100 + '/' +
-            Math.round(mapState.center[1] * 100) / 100 + '/' +
+            centerX + '/' +
+            centerY + '/' +
             mapState.rotation;
 
         // push the state into the window history (to navigate with browser's

--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -250,6 +250,10 @@ Ext.define('CpsiMapview.view.main.Map', {
     applyState: function (mapState) {
         var me = this;
 
+        if (!Ext.isObject(mapState)) {
+            return;
+        }
+
         me.olMap.getView().setCenter(mapState.center);
         me.olMap.getView().setZoom(mapState.zoom);
         me.olMap.getView().setRotation(mapState.rotation);
@@ -263,18 +267,20 @@ Ext.define('CpsiMapview.view.main.Map', {
      * @private
      */
     readPermalink: function (plHash) {
-        var mapState = {};
+        var mapState;
         if (window.location.hash !== '') {
             // read center, zoom and rotation from the URL
             var hash = plHash.replace('#map=', '');
             var parts = hash.split('/');
             if (parts.length === 4) {
-                mapState.zoom = parseInt(parts[0], 10);
-                mapState.center = [
-                    parseFloat(parts[1]),
-                    parseFloat(parts[2])
-                ];
-                mapState.rotation = parseFloat(parts[3]);
+                mapState = {
+                    zoom: parseInt(parts[0], 10),
+                    center: [
+                        parseFloat(parts[1]),
+                        parseFloat(parts[2])
+                    ],
+                    rotation: parseFloat(parts[3])
+                };
             }
         }
 


### PR DESCRIPTION
This records the state for map's zoom, center and rotation and adds it as hash to the current URL.

Inspired by http://openlayers.org/en/v4.6.5/examples/permalink.html

See #23.