### PR TITLE
Introduces timeslider component

### DIFF
--- a/app/controller/panel/TimeSlider.js
+++ b/app/controller/panel/TimeSlider.js
@@ -1,0 +1,170 @@
+/**
+ * This is the controller for the timeslider component
+ */
+Ext.define('CpsiMapview.controller.panel.TimeSlider', {
+    extend: 'Ext.app.ViewController',
+
+    alias: 'controller.cmv_timeslider',
+
+    /**
+     * Function to initialize the time slider called after render
+     * @param {Ext.slider.Single | Ext.slider.Multi} slider The slider to
+     *                                                      initialize
+     */
+    initTimeSlider: function (slider) {
+        var me = this;
+        var viewModel = me.getViewModel();
+        var timeSliderCmp = slider.up('cmv_timeslider');
+        var startDate = timeSliderCmp.startDate;
+        var endDate = timeSliderCmp.endDate;
+        var selectedDate = timeSliderCmp.selectedDate;
+        var timeIncrementUnit = timeSliderCmp.timeIncrementUnit || 'year';
+
+        if (!startDate || !endDate) {
+            Ext.log.warn('Please provide valid start / end date.');
+            return;
+        }
+
+        var timeRangeObj = me.getTimeRangeForDate(startDate, endDate,
+            selectedDate, timeIncrementUnit);
+
+        slider.setMaxValue(timeRangeObj.maxValue);
+        slider.setMinValue(timeRangeObj.minValue);
+
+        viewModel.setData({
+            timeRangeObj: timeRangeObj
+        });
+    },
+
+    /**
+     * Function called in time slider changes
+     * @param {Ext.slider.Single | Ext.slider.Multi} slider The slider
+     * @param {Number} value The new value of the slider
+     */
+    onTimeChanged: function (slider, value) {
+        // TODO: WFS layers must be filtered
+        var me = this;
+        var layerNames = me.getView().layerNames;
+        Ext.each(layerNames, function (layerName) {
+            var layer = BasiGX.util.Layer.getLayerByName(layerName);
+            if (layer && (layer.getSource() instanceof ol.source.TileWMS || layer.getSource() instanceof ol.source.ImageWMS)) {
+                var wmsLayerSource = layer.getSource();
+                var sliderDate = me.getDateForSliderValue(value);
+                if (wmsLayerSource && sliderDate) {
+                    wmsLayerSource.updateParams({
+                        TIME: Ext.Date.format(sliderDate, 'c')
+                    });
+                }
+            }
+        });
+    },
+
+    /**
+     * Function to generate tooltip text for slider
+     *
+     * @param {Ext.slider.Thumb} thumb The Thumb that the tip is attached to
+     * @return {String} The formatted date as text
+     */
+    getTipText: function (thumb) {
+        var me = this;
+        return me.getDateStringForSliderValue(thumb.value);
+    },
+
+    /**
+     * Function that returns formatted date string vor passed slider value
+     *
+     * @param {Number} sliderValue The value of the slider
+     * @return {String} The formatted date as text
+     */
+    getDateStringForSliderValue: function (sliderValue) {
+        var me = this;
+        var view = me.getView();
+        var timeIncrementUnit = view.timeIncrementUnit || 'year';
+        var dateFormat = '';
+        switch (timeIncrementUnit) {
+        case 'month':
+            dateFormat = 'm/Y';
+            break;
+        default:
+            dateFormat = 'Y';
+        }
+        return Ext.Date.format(
+            me.getDateForSliderValue(sliderValue),
+            dateFormat
+        );
+    },
+
+    /**
+     * Function that returns the date vor passed slider value
+     *
+     * @param {Number} sliderValue The value of the slider
+     * @return {Date} The date
+     */
+    getDateForSliderValue: function (sliderValue) {
+        var me = this;
+        var view = me.getView();
+        var timeIncrementUnit = view.timeIncrementUnit || 'year';
+        switch (timeIncrementUnit) {
+        case 'month':
+            var month = sliderValue % 12;
+            var year = (sliderValue - month) / 12;
+            return new Date(1900 + year, month, 1);
+        default:
+            return new Date(1900 + sliderValue, 0, 1);
+        }
+    },
+
+    /**
+     * Map the start date, the enddate and the currently selected date to
+     * valid values for the slider component
+     *
+     * @param {Date} startDate The starting date
+     * @param {Date} endDate The date the slider value should end
+     * @param {Date} selDate The currently selected date
+     * @param {String} timeIncrementUnit The time increment ('year' or 'month')
+     *
+     * @return {Object} Object containing minValue, maxValue and value to be
+     * set in viewModel, for example
+     */
+    getTimeRangeForDate: function (startDate, endDate, selDate,
+        timeIncrementUnit) {
+        // round + floor time to next time unit passed for discretization
+        // => maxValue
+        // get value for selected date => update viewModel
+        var minValue = 0;
+        var maxValue = 100;
+        switch (timeIncrementUnit) {
+        case 'month':
+            minValue = Ext.Date.getFirstDateOfMonth(startDate).getYear()
+                    * 12 + Ext.Date.getFirstDateOfMonth(startDate).getMonth();
+            maxValue = Ext.Date.getLastDateOfMonth(endDate).getYear()
+                    * 12 + Ext.Date.getLastDateOfMonth(endDate).getMonth();
+            break;
+        default:
+            minValue = startDate.getYear();
+            maxValue = endDate.getYear() + 1;
+            break;
+        }
+
+        if (!selDate) {
+            selDate = startDate;
+        }
+
+        var value = 50;
+        switch (timeIncrementUnit) {
+        case 'month':
+            value = Ext.Date.getFirstDateOfMonth(selDate).getYear()
+                    * 12 + Ext.Date.getFirstDateOfMonth(selDate).getMonth();
+            break;
+        default:
+            value = selDate.getYear();
+            break;
+        }
+
+        return {
+            minValue: minValue,
+            maxValue: maxValue,
+            value: value
+        };
+    }
+});

--- a/app/controller/panel/TimeSlider.js
+++ b/app/controller/panel/TimeSlider.js
@@ -62,16 +62,15 @@ Ext.define('CpsiMapview.controller.panel.TimeSlider', {
     /**
      * Function to generate tooltip text for slider
      *
-     * @param {Ext.slider.Thumb} thumb The Thumb that the tip is attached to
+     * @param {Ext.slider.Thumb} thumb The thumb that the tip is attached to
      * @return {String} The formatted date as text
      */
     getTipText: function (thumb) {
-        var me = this;
-        return me.getDateStringForSliderValue(thumb.value);
+        return this.getDateStringForSliderValue(thumb.value);
     },
 
     /**
-     * Function that returns formatted date string vor passed slider value
+     * Function that returns formatted date string for passed slider value
      *
      * @param {Number} sliderValue The value of the slider
      * @return {String} The formatted date as text

--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -48,6 +48,11 @@ Ext.define('CpsiMapview.view.main.Map', {
             listeners: {
                 afterrender: 'initializeMeasureBtn'
             }
+        }, {
+            xtype: 'cmv_timeslider',
+            startDate: new Date(1998, 0, 1),
+            endDate: new Date(Date.now()),
+            layerNames: [] // TODO: fill me
         }]
     }, {
         xtype: 'cmv_mapfooter',

--- a/app/view/panel/TimeSlider.js
+++ b/app/view/panel/TimeSlider.js
@@ -63,12 +63,12 @@ Ext.define('CpsiMapview.view.panel.TimeSlider', {
             width: 250,
             listeners: {
                 change: 'onTimeChanged',
-                afterrender: 'initTimeSlider'
+                beforerender: 'initTimeSlider'
             },
             bind: {
                 value: '{timeRangeObj.value}'
             },
-            tipText: me.getController().getTipText.bind(me.getController())
+            tipText: 'getTipText'
         },
         {
             xtype: 'checkbox',

--- a/app/view/panel/TimeSlider.js
+++ b/app/view/panel/TimeSlider.js
@@ -1,0 +1,86 @@
+/**
+ * This class is the time slider component of cpsi mapview application
+ */
+Ext.define('CpsiMapview.view.panel.TimeSlider', {
+    extend: 'Ext.panel.Panel',
+    xtype: 'cmv_timeslider',
+
+    requires: [
+        'Ext.slider.Single',
+
+        'CpsiMapview.controller.panel.TimeSlider'
+    ],
+
+    controller: 'cmv_timeslider',
+
+    layout: 'hbox',
+
+    /**
+     *
+     */
+    viewModel: {
+        data: {
+            timeRangeObj: {
+                minValue: 0,
+                maxValue: 10,
+                value: 5
+            },
+            isRange: false
+        }
+    },
+
+    /**
+     * The selected date (after initialization) as Date object
+     */
+    selectedDate: null,
+    /**
+     * The start date of slider
+     */
+    startDate: null,
+    /**
+     * The end date of slider
+     */
+    endDate: null,
+    /**
+     * The unit of time increment (currently only year and month supported)
+     */
+    timeIncrementUnit: 'year',
+    /**
+     * The names of the layers that should listen to chages in slider
+     */
+    layerNames: [],
+
+    /**
+     *
+     */
+    initComponent: function () {
+        var me = this;
+        me.items = [{
+            fieldLabel: 'Time',
+            xtype: 'slider',
+            labelAlign: 'right',
+            flex: 6,
+            width: 250,
+            listeners: {
+                change: 'onTimeChanged',
+                afterrender: 'initTimeSlider'
+            },
+            bind: {
+                value: '{timeRangeObj.value}'
+            },
+            tipText: me.getController().getTipText.bind(me.getController())
+        },
+        {
+            xtype: 'checkbox',
+            name: 'range',
+            fieldLabel: 'Time range',
+            labelAlign: 'right',
+            bind: {
+                value: '{isRange}'
+            }
+        }];
+
+        me.callParent();
+    }
+
+});


### PR DESCRIPTION
This is a initial check in of the TimeSlider component (see #24). Currently, the following functionality is available:
* Update `ImageWMS` and `TileWMS` layers given in `layers array`, in particular parameter `TIME`
* Calculate the slider's increment, maxValue and minValue depending on selected time unit (currently year and month), the start time and the end time
* Pass a currently selected date to component

![image](https://user-images.githubusercontent.com/10559603/48554800-ad70c500-e8df-11e8-8375-6527fbeaf7e5.png)

Open issues:
* Support WFS layers
* Support time ranges