### PR TITLE
Show legends underneath visible layer entries in the tree

### DIFF
--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -71,11 +71,15 @@ Ext.define('CpsiMapview.factory.Layer', {
         }
 
         // This is the same for all types
-        if (mapLayer && layerConf.isBaseLayer) {
-            mapLayer.set('isBaseLayer', true);
-            mapLayer.on(
-                'change:visible', LayerFactory.ensureOnlyOneBaseLayerVisible
-            );
+        if (mapLayer) {
+            // handle base layer logic
+            if (layerConf.isBaseLayer) {
+                mapLayer.set('isBaseLayer', true);
+                mapLayer.on(
+                    'change:visible', LayerFactory.ensureOnlyOneBaseLayerVisible
+                );
+            }
+            // assign relevant legend properties
             mapLayer.set('legendUrl', layerConf.legendUrl);
             mapLayer.set('legendHeight', layerConf.legendHeight);
             mapLayer.set('legendWidth', layerConf.legendWidth);

--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -70,11 +70,15 @@ Ext.define('CpsiMapview.factory.Layer', {
             //do nothing, and return empty layer
         }
 
+        // This is the same for all types
         if (mapLayer && layerConf.isBaseLayer) {
             mapLayer.set('isBaseLayer', true);
             mapLayer.on(
                 'change:visible', LayerFactory.ensureOnlyOneBaseLayerVisible
             );
+            mapLayer.set('legendUrl', layerConf.legendUrl);
+            mapLayer.set('legendHeight', layerConf.legendHeight);
+            mapLayer.set('legendWidth', layerConf.legendWidth);
         }
 
         return mapLayer;

--- a/app/plugin/BasicTreeColumnLegends.js
+++ b/app/plugin/BasicTreeColumnLegends.js
@@ -1,0 +1,110 @@
+/**
+ * A plugin for Ext.grid.column.Column s that overwrites the internal cellTpl to
+ * support legends.
+ */
+Ext.define('CpsiMapview.plugin.BasicTreeColumnLegends', {
+    extend: 'Ext.plugin.Abstract',
+    alias: 'plugin.basic_tree_column_legend',
+    pluginId: 'basic_tree_column_legend',
+
+    /**
+     * @private
+     */
+    originalCellTpl: Ext.clone(Ext.tree.Column.prototype.cellTpl).join(''),
+
+    /**
+     * The Xtemplate strings that will be used instead of the plain {value}
+     * when rendering
+     * We add a additional div in order to expand and collapse the legends. The syntax in templates is picky here...
+     */
+    valueReplacementTpl: [
+        '{value}',
+        '<tpl if="this.hasLegend(values.record)"><br />',
+        '<tpl for="lines">',
+        '<img src="{parent.blankUrl}"',
+        ' class="{parent.childCls} {parent.elbowCls}-img ',
+        '{parent.elbowCls}-<tpl if=".">line<tpl else>empty</tpl>"',
+        ' role="presentation"/>',
+        '</tpl>',
+        '<img src="{blankUrl}" class="{childCls} x-tree-elbow-img">',
+        '<img src="{blankUrl}" class="{childCls} x-tree-elbow-img">',
+        '<img src="{blankUrl}" class="{childCls} x-tree-elbow-img">',
+        '{[this.getLegendHtml(values.record)]}',
+        '</tpl>'
+    ],
+
+    /**
+     * The context for methods available in the template
+     */
+    valueReplacementContext: {
+        hasLegend: function(rec) {
+            var isChecked = rec.get('checked');
+            var layer = rec.data;
+            return isChecked && !(layer instanceof ol.layer.Group);
+        },
+        getLegendHtml: function(rec) {
+            var staticMe = CpsiMapview.plugin.BasicTreeColumnLegends;
+            var layer = rec.data;
+            var legendUrl = layer.get('legendUrl');
+            var w = layer.get('legendWidth');
+            var h = layer.get('legendHeight');
+            if (!legendUrl) {
+                // 1px×1px transparent gif
+                legendUrl = staticMe.transparentGif;
+                w = h = 1;
+            }
+            // if the legend cannot be obtained (which happens e.g. for cascaded
+            // WMS layers, as geoserver does not support legends for these
+            // layers) we remove the broken image and the othe rdom elements
+            // that therwise would lead to vertcial gap between layers in the
+            // tree.
+            var ns = 'CpsiMapview.plugin.BasicTreeColumnLegends';
+            return '<img' +
+                ' class="cpsi-layer-legend"' +
+                ' src="' + legendUrl + '"' +
+                (w ? ' width="' + w + '"' : '') +
+                (h ? ' height="' + h + '"' : '') +
+                ' onerror="' + ns + '.checkCleanup(this);"' +
+                ' onload="' + ns + '.checkCleanup(this);"' +
+                '/>';
+        }
+    },
+
+    statics: {
+        transparentGif: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP' +
+            '///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
+        checkCleanup: function(img) {
+            var staticMe = CpsiMapview.plugin.BasicTreeColumnLegends;
+            var el = Ext.get(img);
+            var w = parseInt(el.getAttribute('width'), 10);
+            var h = parseInt(el.getAttribute('height'), 10);
+            var src = el.getAttribute('src');
+            if(w === 1 && h === 1 && src === staticMe.transparentGif) {
+                var parent = Ext.get(img.parentNode);
+                var removeElems = parent.query('br, img');
+                Ext.each(removeElems, function(removeElem) {
+                    Ext.get(removeElem).destroy();
+                });
+            }
+        }
+    },
+
+    init: function(column) {
+        var me = this;
+        if (!(column instanceof Ext.grid.column.Column)) {
+            Ext.log.warn('Plugin shall only be applied to instances of' +
+                    ' Ext.grid.column.Column');
+            return;
+        }
+        var valuePlaceHolderRegExp = /\{value\}/g;
+        var replacementTpl = me.valueReplacementTpl.join('');
+        var newCellTpl = me.originalCellTpl.replace(
+            valuePlaceHolderRegExp, replacementTpl
+        );
+
+        column.cellTpl = [
+            newCellTpl,
+            me.valueReplacementContext
+        ];
+    }
+});

--- a/app/plugin/BasicTreeColumnLegends.js
+++ b/app/plugin/BasicTreeColumnLegends.js
@@ -1,5 +1,5 @@
 /**
- * A plugin for Ext.grid.column.Column s that overwrites the internal cellTpl to
+ * A plugin for Ext.grid.column.Column that overwrites the internal cellTpl to
  * support legends.
  */
 Ext.define('CpsiMapview.plugin.BasicTreeColumnLegends', {
@@ -55,8 +55,8 @@ Ext.define('CpsiMapview.plugin.BasicTreeColumnLegends', {
             }
             // if the legend cannot be obtained (which happens e.g. for cascaded
             // WMS layers, as geoserver does not support legends for these
-            // layers) we remove the broken image and the othe rdom elements
-            // that therwise would lead to vertcial gap between layers in the
+            // layers) we remove the broken image and the other dom elements
+            // that otherwise would lead to vertical gap between layers in the
             // tree.
             var ns = 'CpsiMapview.plugin.BasicTreeColumnLegends';
             return '<img' +

--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -6,15 +6,31 @@ Ext.define('CpsiMapview.view.LayerTree', {
     xtype: 'cmv_layertree',
     requires: [
         'BasiGX.util.Map',
-        'GeoExt.data.store.LayersTree'
+        'GeoExt.data.store.LayersTree',
+        'CpsiMapview.plugin.BasicTreeColumnLegends'
     ],
-
     // So that instanciation works without errors, might be changed during
     // instanciation of the LayerTree.
     store: {},
     rootVisible: false,
     viewConfig: {
         plugins: { ptype: 'treeviewdragdrop' }
+    },
+    hideHeaders: true,
+    lines: false,
+    flex: 1,
+    columns: {
+        header: false,
+        items: [
+            {
+                xtype: 'treecolumn',
+                dataIndex: 'text',
+                flex: 1,
+                plugins: [{
+                    ptype: 'basic_tree_column_legend'
+                }]
+            }
+        ]
     },
 
     /**

--- a/app/view/main/Main.js
+++ b/app/view/main/Main.js
@@ -33,6 +33,10 @@ Ext.define('CpsiMapview.view.main.Main', {
         region: 'west',
         width: 300,
         collapsible: true,
+        layout: {
+            type: 'vbox',
+            align: 'stretch'
+        },
         items: {
             xtype: 'cmv_layertree'
         }

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -21,6 +21,8 @@
     "isBaseLayer": true,
     "isDefaultBaseLayer": true,
     "text": "OpenStreetMap",
+    "legendUrl": "https://a.tile.openstreetmap.org/9/244/166.png",
+    "legendHeight": 100,
     "openLayers": {
       "maxResolution": 1222.99245234375,
       "numZoomLevels": 12,

--- a/sass/src/view/LayerTree.scss
+++ b/sass/src/view/LayerTree.scss
@@ -1,0 +1,5 @@
+.cpsi-layer-legend {
+    margin: 3px 0 0 0;
+    border: 1px solid transparent;
+    border-radius: 6px;
+}


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/227934/48627664-6d7c1180-e9b5-11e8-945d-e0437687ac6a.png)

I went the very easy way instead of using the Legendtree of BasiGX, with which I had more trouble than expected.

Layers that have a `legendUrl` configured (with optional `legendWidth` and/or `legendHeight`) will have alegend underneath them. Future variants might use more logic to create legends on-the-fly for vector layer e.g. For this iteration we agreed on URLs as a minimal step.

Please review.

Fixes #26