### PR TITLE
Time range functionality for WFS layers

### DIFF
--- a/app/controller/panel/TimeSlider.js
+++ b/app/controller/panel/TimeSlider.js
@@ -78,12 +78,13 @@ Ext.define('CpsiMapview.controller.panel.TimeSlider', {
                 var dateFormat = layer.get('dateFormat') || 'C';
                 if (layerSource && (layerSource instanceof ol.source.TileWMS || layerSource instanceof ol.source.ImageWMS)) {
                     layerSource.updateParams({
-                        TIME: me.formatWmsDateString(values, isRange, timeIncrementUnit, dateFormat)
+                        TIME: me.formatDateString(values, isRange, timeIncrementUnit, dateFormat)
                     });
                 }
                 if (layerSource instanceof ol.source.Vector) {
-                    var timeString = me.formatWmsDateString(values, isRange, timeIncrementUnit, dateFormat);
-                    var filterParts = BasiGX.util.WFS.getTimeFilterParts(layer, 'time', timeString);
+                    var timeProperty = layer.get('timeProperty') || 'time';
+                    var timeString = me.formatDateString(values, isRange, timeIncrementUnit, dateFormat);
+                    var filterParts = BasiGX.util.WFS.getTimeFilterParts(layer, timeProperty, timeString);
                     layerSource.set('timeFilters', filterParts);
                     layerSource.clear(true);
                 }
@@ -103,9 +104,9 @@ Ext.define('CpsiMapview.controller.panel.TimeSlider', {
      *
      * @returns {String} The formatted time string
      */
-    formatWmsDateString: function (values, isRange, timeIncrementUnit, dateFormat) {
+    formatDateString: function (values, isRange, timeIncrementUnit, dateFormat) {
         var me = this;
-        // we must check for min / max here since the thumbs are not contrained
+        // we must check for min / max here since the thumbs are not constrained
         var startDate = me.getDateForSliderValue(Ext.Array.min(values));
         var endDate = me.getDateForSliderValue(Ext.Array.max(values));
 

--- a/app/controller/panel/TimeSlider.js
+++ b/app/controller/panel/TimeSlider.js
@@ -7,7 +7,8 @@ Ext.define('CpsiMapview.controller.panel.TimeSlider', {
     alias: 'controller.cmv_timeslider',
 
     requires: [
-        'BasiGX.util.Layer'
+        'BasiGX.util.Layer',
+        'BasiGX.util.WFS'
     ],
 
     /**
@@ -69,15 +70,22 @@ Ext.define('CpsiMapview.controller.panel.TimeSlider', {
     onTimeChanged: function (slider, isRange) {
         var me = this;
         var values = slider.getValues();
+        var timeIncrementUnit = slider.up('cmv_timeslider').timeIncrementUnit || 'year';
         var timeLayers = BasiGX.util.Layer.getLayersBy('isTimeDedendent', true);
-        // TODO: WFS layers must be filtered
         Ext.each(timeLayers, function (layer) {
-            if (layer && (layer.getSource() instanceof ol.source.TileWMS || layer.getSource() instanceof ol.source.ImageWMS)) {
-                var wmsLayerSource = layer.getSource();
-                if (wmsLayerSource) {
-                    wmsLayerSource.updateParams({
-                        TIME: me.formatWmsDateString(values, isRange)
+            if (layer) {
+                var layerSource = layer.getSource();
+                var dateFormat = layer.get('dateFormat') || 'C';
+                if (layerSource && (layerSource instanceof ol.source.TileWMS || layerSource instanceof ol.source.ImageWMS)) {
+                    layerSource.updateParams({
+                        TIME: me.formatWmsDateString(values, isRange, timeIncrementUnit, dateFormat)
                     });
+                }
+                if (layerSource instanceof ol.source.Vector) {
+                    var timeString = me.formatWmsDateString(values, isRange, timeIncrementUnit, dateFormat);
+                    var filterParts = BasiGX.util.WFS.getTimeFilterParts(layer, 'time', timeString);
+                    layerSource.set('timeFilters', filterParts);
+                    layerSource.clear(true);
                 }
             }
         });
@@ -89,16 +97,34 @@ Ext.define('CpsiMapview.controller.panel.TimeSlider', {
      *
      * @param {Number[]} values The slider values
      * @param {Boolean} isRange Is range query or not
+     * @param {String} timeIncrementUnit The unit of time increment (year / month)
+     * @param {String} dateFormat The date format as listed in ExtJS documentation
+     * https://docs.sencha.com/extjs/6.2.1/classic/Ext.Date.html
      *
      * @returns {String} The formatted time string
      */
-    formatWmsDateString: function (values, isRange) {
+    formatWmsDateString: function (values, isRange, timeIncrementUnit, dateFormat) {
         var me = this;
         // we must check for min / max here since the thumbs are not contrained
-        var startDateStr = me.getDateStringForSliderValue(Ext.Array.min(values));
-        var endDateStr = me.getDateStringForSliderValue(Ext.Array.max(values));
-        // TODO: format can be layer dependent....
-        return Ext.String.format('{0}/{1}', startDateStr, isRange ? endDateStr : startDateStr);
+        var startDate = me.getDateForSliderValue(Ext.Array.min(values));
+        var endDate = me.getDateForSliderValue(Ext.Array.max(values));
+
+        if (!startDate || !endDate) {
+            return;
+        }
+
+        // ceil / floor year according to selected interval if month is time increment
+        if (timeIncrementUnit === 'month') {
+            startDate = Ext.Date.getFirstDateOfMonth(startDate);
+            endDate = Ext.Date.getLastDateOfMonth(endDate);
+        } else {
+            // last day of year
+            endDate = new Date(!isRange ? startDate.getFullYear() : endDate.getFullYear(), 11, 31);
+        }
+
+        var startDateStr = Ext.Date.format(startDate, dateFormat);
+        var endDateStr = Ext.Date.format(endDate, dateFormat);
+        return Ext.String.format('{0}/{1}', startDateStr, endDateStr);
     },
 
     /**

--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -148,7 +148,8 @@ Ext.define('CpsiMapview.factory.Layer', {
         var olLayerConf = {
             name: layerConf.text,
             isTimeDedendent: !!layerConf.timeitem,
-            dateFormat: layerConf.dateFormat
+            dateFormat: layerConf.dateFormat,
+            timeProperty: layerConf.timeitem
         };
         olLayerConf = Ext.apply(olLayerConf, olLayerProps);
 
@@ -203,7 +204,7 @@ Ext.define('CpsiMapview.factory.Layer', {
 
         var vectorSource = new ol.source.Vector(olSourceConf);
 
-        var loaderFn = function (extent) {
+        var loaderFn = function(extent) {
             vectorSource.dispatchEvent('vectorloadstart');
 
             var allFilters = [];
@@ -273,7 +274,8 @@ Ext.define('CpsiMapview.factory.Layer', {
             source: clusterSource ? clusterSource : vectorSource,
             toolTipConfig: layerConf.tooltipsConfig,
             isTimeDedendent: !!layerConf.timeitem,
-            dateFormat: layerConf.dateFormat
+            dateFormat: layerConf.dateFormat,
+            timeProperty: layerConf.timeitem
         };
         olLayerConf = Ext.apply(olLayerConf, olLayerProps);
 

--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -66,8 +66,8 @@ Ext.define('CpsiMapview.view.main.Map', {
             glyph: 'xf105@FontAwesome'
         }, {
             xtype: 'cmv_timeslider',
-            startDate: new Date(1900, 0, 1),
-            endDate: new Date(2040, 11, 30)
+            startDate: new Date(2009, 0, 1),
+            endDate: new Date(2018, 11, 30)
         }]
     }, {
         xtype: 'cmv_mapfooter',

--- a/nginx.conf
+++ b/nginx.conf
@@ -5,7 +5,13 @@ events {
 http {
   server {
       listen 80;
-      server_name     cspi-dev;
+      server_name     cspi;
+
+      location /wfs/ {
+          # Please replace IP.IP.IP.IP with the ip where your dev geoserver / WFS server
+          # runs
+          proxy_pass http://IP.IP.IP.IP:1235/geoserver/wfs/;
+      }
 
       location /mapserver/ {
           # Please repace WMSSERVER.WMSSERVER with running instance of WMS

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -116,7 +116,7 @@
     "featureType": "test:osm-fuel",
     "serverOptions": {},
     "noCluster": true,
-    "timeitem": "TIME",
+    "timeitem": "time",
     "dateFormat": "c",
     "geometryProperty": "the_geom",
     "openLayers": {

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -101,6 +101,7 @@
     "isBaseLayer": false,
     "isDefaultBaseLayer": false,
     "timeitem": "TIME",
+    "dateFormat": "Y",
     "serverOptions": {
       "layers": "Works_Type",
       "version": "1.1.1"

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -109,5 +109,22 @@
     "openLayers": {
       "singleTile": true
     }
+  }, {
+    "layerType": "wfs",
+    "text": "Test time WFS",
+    "url": "wfs/",
+    "featureType": "test:osm-fuel",
+    "serverOptions": {},
+    "noCluster": true,
+    "timeitem": "TIME",
+    "dateFormat": "c",
+    "geometryProperty": "the_geom",
+    "openLayers": {
+      "maxResolution": 1222.99245234375,
+      "numZoomLevels": 12,
+      "opacity": 0.7,
+      "projection": "EPSG:900913",
+      "visibility": true
+    }
   }]
 }


### PR DESCRIPTION
This PR enabled time-dependent WFS layer by adding a filter to WFS request containing time interval.

In addition, a new property to define date format for each layer was introduces (closes issue #50)

This PR depends on https://github.com/meggsimum/cpsi-mapview/pull/49, which should be merged before.