### PR TITLE
Map "openLayers" properties of JSON configuration 

### DIFF
--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -140,7 +140,7 @@ Ext.define('CpsiMapview.factory.Layer', {
                 'TRANSPARENT': true,
                 'TILED': !singleTile
             },
-            ratio: singleTile? 1 : undefined,
+            ratio: singleTile ? 1 : undefined,
             crossOrigin: 'anonymous'
         };
         olSourceConf = Ext.apply(olSourceConf, olSourceProps);


### PR DESCRIPTION
This adds two functions (`ol2PropsToOlLayerProps` and `ol2PropsToOlSourceProps`) to the `LayerFactory`, which transform the ol2-based properties of the JSON-configuration to ol4 pendants.

This cleans up the code and ensures all possible `"openLayers"` config properties are interpreted (where possible)

Related to #10 

