### PR TITLE
Harmonize aliases 

### DIFF
--- a/app/model/button/MeasureButton.js
+++ b/app/model/button/MeasureButton.js
@@ -4,7 +4,7 @@
 Ext.define('CpsiMapview.model.button.MeasureButton', {
     extend: 'Ext.app.ViewModel',
 
-    alias: 'viewmodel.cmw_btn_measure',
+    alias: 'viewmodel.cmv_btn_measure',
 
     data: {
         measureTooltext: null, // don't show text

--- a/app/plugin/BasicTreeColumnLegends.js
+++ b/app/plugin/BasicTreeColumnLegends.js
@@ -4,8 +4,8 @@
  */
 Ext.define('CpsiMapview.plugin.BasicTreeColumnLegends', {
     extend: 'Ext.plugin.Abstract',
-    alias: 'plugin.basic_tree_column_legend',
-    pluginId: 'basic_tree_column_legend',
+    alias: 'plugin.cmv_basic_tree_column_legend',
+    pluginId: 'cmv_basic_tree_column_legend',
 
     /**
      * @private

--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -27,7 +27,7 @@ Ext.define('CpsiMapview.view.LayerTree', {
                 dataIndex: 'text',
                 flex: 1,
                 plugins: [{
-                    ptype: 'basic_tree_column_legend'
+                    ptype: 'cmv_basic_tree_column_legend'
                 }]
             }
         ]

--- a/app/view/toolbar/MapTools.js
+++ b/app/view/toolbar/MapTools.js
@@ -32,7 +32,7 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
             xtype: 'basigx-button-measure',
             measureType: 'line',
             toggleGroup: 'measure-tools',
-            viewModel: 'cmw_btn_measure',
+            viewModel: 'cmv_btn_measure',
             controller: 'cmv_btn_measure',
             glyph: 'xf068@FontAwesome',
             listeners: {
@@ -43,7 +43,7 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
             measureType: 'polygon',
             toggleGroup: 'measure-tools',
             glyph: 'xf044@FontAwesome',
-            viewModel: 'cmw_btn_measure',
+            viewModel: 'cmv_btn_measure',
             controller: 'cmv_btn_measure',
             listeners: {
                 afterrender: 'initializeMeasureBtn'


### PR DESCRIPTION
This harmonizes the alias for `MeasureButton` ViewModel and the ptype for `BasicTreeColumnLegends`.

@geographika: If this gets merged the following has to be adapted as well: https://github.com/compassinformatics/publiclighting/blob/master/app/view/main/Map.js#L42 

Closes #61  