### PR TITLE
Grouped layers as folders in LayerTree

### DIFF
--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -85,6 +85,11 @@ Ext.define('CpsiMapview.factory.Layer', {
             mapLayer.set('legendUrl', layerConf.legendUrl);
             mapLayer.set('legendHeight', layerConf.legendHeight);
             mapLayer.set('legendWidth', layerConf.legendWidth);
+
+            // this gets transformed to qtip on the layer tree node
+            mapLayer.set('description', layerConf.qtip);
+            // changes the icon in the layer tree leaf
+            mapLayer.set('iconCls', layerConf.iconCls);
         }
 
         return mapLayer;

--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -106,6 +106,10 @@ Ext.define('CpsiMapview.view.LayerTree', {
     /**
      * Given a `ol.Map` this method will return an instance of the GeoExt class
      * GeoExt.data.store.LayersTree, which will work on the topmost layergroup.
+     * In case this store is configured with `this.structureMode ===
+     * 'BASELAYER_OVERLAY'` the layers of the `ol.Map` are restructured and
+     * divided into two groups ('Base Layer' and 'Overlays'). This assures that
+     * the layers will appear in two folders in a connected TreePanel.
      *
      * @param  {ol.Map} map The map to create the store from.
      * @return {GeoExt.data.store.LayersTree} The created store.
@@ -120,7 +124,6 @@ Ext.define('CpsiMapview.view.LayerTree', {
             // overlays. Then recreates the LayerStore and applies it to this
             // tree.
             var regroupLayerStore = function () {
-
                 // create group layers
                 var finalLayerGroup = me.getGroupedLayers(map);
                 map.setLayerGroup(finalLayerGroup);
@@ -154,7 +157,7 @@ Ext.define('CpsiMapview.view.LayerTree', {
     /**
      * Re-groups the layers of the given map, so they are divided between base
      * layers and overlays.
-     * For each type a layer an OL layer group is created and aggregated in a
+     * For each type an OL layer group is created and aggregated in a
      * root layer group.
      *
      * @param  {ol.Map} allLayers The map to get the grouped layers for

--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -130,6 +130,9 @@ Ext.define('CpsiMapview.view.LayerTree', {
                     layerGroup: map.getLayerGroup()
                 });
                 me.setStore(groupedStore);
+
+                // expand all folders in this tree
+                me.expandAll();
             };
 
             // check if all layers have been loaded already
@@ -140,7 +143,6 @@ Ext.define('CpsiMapview.view.LayerTree', {
             } else {
                 regroupLayerStore();
             }
-
         }
 
         return store;

--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -9,6 +9,14 @@ Ext.define('CpsiMapview.view.LayerTree', {
         'GeoExt.data.store.LayersTree',
         'CpsiMapview.plugin.BasicTreeColumnLegends'
     ],
+
+    viewModel: {
+        data: {
+            baseLayerGroupText: 'Base Layers',
+            overlayGroupText: 'Layers',
+        }
+    },
+
     // So that instanciation works without errors, might be changed during
     // instanciation of the LayerTree.
     store: {},
@@ -164,6 +172,7 @@ Ext.define('CpsiMapview.view.LayerTree', {
      * @return {ol.layer.Group}   Root layer group holding groups for base layers and overlays
      */
     getGroupedLayers: function (map) {
+        var me = this;
         var allLayers = map.getLayerGroup().getLayers().getArray();
         var baseLayers = [];
         var overlays = [];
@@ -178,12 +187,12 @@ Ext.define('CpsiMapview.view.LayerTree', {
         });
 
         var baseLayerGroup = new ol.layer.Group({
-            name: 'Base Layers',
+            name: me.getViewModel().get('baseLayerGroupText'),
             layers: baseLayers,
             expanded: true
         });
         var overlayGroup = new ol.layer.Group({
-            name: 'Overlays',
+            name: me.getViewModel().get('overlayGroupText'),
             layers: overlays
         });
         var rootLayerGroup = new ol.layer.Group({

--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -34,6 +34,24 @@ Ext.define('CpsiMapview.view.LayerTree', {
     },
 
     /**
+     * Mode in order to steer how the layers in tree will be structured.
+     * At the moment 'BASELAYER_OVERLAY' will divide the layers in 2 folders
+     * 'Base Layers' and 'Overlays' (depending on their property 'isBaseLayer').
+     * All other settings will result in a flat layer list.
+     *
+     * @cfg {String}
+     */
+    structureMode: null,
+
+    /**
+     * Shows if the event 'cmv-init-layersadded' has been fired or not.
+     *
+     * @property {Boolean}
+     * @private
+     */
+    initLayersAdded: false,
+
+    /**
      * Constructor which either directly assigns a GeoExt.data.store.LayersTree
      * or sets up a listener which does this as soon as the application itself
      * fires the `mapready`-event.
@@ -42,14 +60,29 @@ Ext.define('CpsiMapview.view.LayerTree', {
      */
     constructor: function(cfg) {
         var me = this;
+
+        me.callParent([cfg]);
+
         var mapComp = BasiGX.util.Map.getMapComponent();
         var map = mapComp && mapComp.getMap();
         if (map) {
-            cfg.store = me.makeLayerStore(map);
+            me.setStore(me.makeLayerStore(map));
         } else {
             Ext.GlobalEvents.on('cmv-mapready', me.autoConnectToMap);
         }
-        me.callParent([cfg]);
+    },
+
+    /**
+     * @private
+     */
+    initComponent: function () {
+        var me = this;
+        var mapPanel = CpsiMapview.view.main.Map.guess();
+        mapPanel.on('cmv-init-layersadded', function () {
+            me.initLayersAdded = true;
+        });
+
+        me.callParent();
     },
 
     /**
@@ -77,8 +110,79 @@ Ext.define('CpsiMapview.view.LayerTree', {
      * @return {GeoExt.data.store.LayersTree} The created store.
      */
     makeLayerStore: function(map) {
-        return Ext.create('GeoExt.data.store.LayersTree', {
+        var me = this;
+        var mapPanel = CpsiMapview.view.main.Map.guess();
+
+        var store = Ext.create('GeoExt.data.store.LayersTree', {
             layerGroup: map.getLayerGroup()
         });
+
+        if (me.structureMode === 'BASELAYER_OVERLAY') {
+            // re-groups the map layers by divding them between base layers and
+            // overlays. Then recreates the LayerStore and applies it to this
+            // tree.
+            var regroupLayerStore = function () {
+                // create group layers
+                var finalLayerGroup = me.getGroupedLayers(map);
+                map.setLayerGroup(finalLayerGroup);
+                // create a new LayerStore from the grouped layers
+                var groupedStore = Ext.create('GeoExt.data.store.LayersTree', {
+                    layerGroup: map.getLayerGroup()
+                });
+                me.setStore(groupedStore);
+            };
+
+            // check if all layers have been loaded already
+            if (!me.initLayersAdded) {
+                mapPanel.on('cmv-init-layersadded', function () {
+                    regroupLayerStore();
+                });
+            } else {
+                regroupLayerStore();
+            }
+
+        }
+
+        return store;
+    },
+
+    /**
+     * Re-groups the layers of the given map, so they are divided between base
+     * layers and overlays.
+     * For each type a layer an OL layer group is created and aggregated in a
+     * root layer group.
+     *
+     * @param  {ol.Map} allLayers The map to get the grouped layers for
+     * @return {ol.layer.Group}   Root layer group holding groups for base layers and overlays
+     */
+    getGroupedLayers: function (map) {
+        var allLayers = map.getLayerGroup().getLayers().getArray();
+        var baseLayers = [];
+        var overlays = [];
+
+        // iterate over all layers and divide between base layers and overlays
+        Ext.each(allLayers, function (layer) {
+            if (layer.get('isBaseLayer') === true) {
+                baseLayers.push(layer);
+            } else {
+                overlays.push(layer);
+            }
+        });
+
+        var baseLayerGroup = new ol.layer.Group({
+            name: 'Base Layers',
+            layers: baseLayers,
+            expanded: true
+        });
+        var overlayGroup = new ol.layer.Group({
+            name: 'Overlays',
+            layers: overlays
+        });
+        var rootLayerGroup = new ol.layer.Group({
+            layers: [baseLayerGroup, overlayGroup],
+            visible: true
+        });
+
+        return rootLayerGroup;
     }
 });

--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -78,6 +78,7 @@ Ext.define('CpsiMapview.view.LayerTree', {
     initComponent: function () {
         var me = this;
         var mapPanel = CpsiMapview.view.main.Map.guess();
+
         mapPanel.on('cmv-init-layersadded', function () {
             me.initLayersAdded = true;
         });
@@ -112,16 +113,14 @@ Ext.define('CpsiMapview.view.LayerTree', {
     makeLayerStore: function(map) {
         var me = this;
         var mapPanel = CpsiMapview.view.main.Map.guess();
-
-        var store = Ext.create('GeoExt.data.store.LayersTree', {
-            layerGroup: map.getLayerGroup()
-        });
+        var store;
 
         if (me.structureMode === 'BASELAYER_OVERLAY') {
             // re-groups the map layers by divding them between base layers and
             // overlays. Then recreates the LayerStore and applies it to this
             // tree.
             var regroupLayerStore = function () {
+
                 // create group layers
                 var finalLayerGroup = me.getGroupedLayers(map);
                 map.setLayerGroup(finalLayerGroup);
@@ -143,6 +142,10 @@ Ext.define('CpsiMapview.view.LayerTree', {
             } else {
                 regroupLayerStore();
             }
+        } else {
+            store = Ext.create('GeoExt.data.store.LayersTree', {
+                layerGroup: map.getLayerGroup()
+            });
         }
 
         return store;

--- a/app/view/main/Main.js
+++ b/app/view/main/Main.js
@@ -38,7 +38,8 @@ Ext.define('CpsiMapview.view.main.Main', {
             align: 'stretch'
         },
         items: {
-            xtype: 'cmv_layertree'
+            xtype: 'cmv_layertree',
+            structureMode: 'BASELAYER_OVERLAY'
         }
     }, {
         xtype: 'cmv_header'

--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -129,6 +129,9 @@ Ext.define('CpsiMapview.view.main.Map', {
                     }
                 });
 
+                // fire event to inform subscribers that all layers are loaded
+                me.fireEvent('cmv-init-layersadded', me);
+
                 var timeSlider = me.down('cmv_timeslider');
                 if (timeSlider) {
                     timeSlider.fireEvent('allLayersAdded',

--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -99,6 +99,12 @@ Ext.define('CpsiMapview.view.main.Map', {
      * @param {ol.MapBrowserEvent)} evt The original 'singleclick' event of OpenLayers
      */
 
+    /**
+     * @event cmv-init-layersadded
+     * Fires when all initial layers from the config have been created and added to the OL map.
+     * @param {CpsiMapview.view.main.Map} this
+     */
+
     inheritableStatics: {
         /**
          * Tries to detect the first occurance of this map panel.

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -34,7 +34,7 @@
   }, {
     "layerType": "wms",
     "helpPage": "OSM",
-    "qtip": "Am OSM based WMS layer",
+    "qtip": "An OSM based WMS layer",
     "iconCls": "map",
     "isBaseLayer": false,
     "isDefaultBaseLayer": false,
@@ -54,7 +54,7 @@
   }, {
     "layerType": "wfs",
     "text": "Country WFS",
-    "qtip": "Am OSM based WFS layer",
+    "qtip": "An OSM based WFS layer",
     "url": "https://ows.terrestris.de/geoserver/osm/wfs",
     "featureType": "osm:osm-country-borders",
     "serverOptions": {},

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -34,6 +34,7 @@
   }, {
     "layerType": "wms",
     "helpPage": "OSM",
+    "qtip": "Am OSM based WMS layer",
     "iconCls": "map",
     "isBaseLayer": false,
     "isDefaultBaseLayer": false,
@@ -53,6 +54,7 @@
   }, {
     "layerType": "wfs",
     "text": "Country WFS",
+    "qtip": "Am OSM based WFS layer",
     "url": "https://ows.terrestris.de/geoserver/osm/wfs",
     "featureType": "osm:osm-country-borders",
     "serverOptions": {},


### PR DESCRIPTION
This introduces the possibility to group the layers in the `TreePanel` based on their `isBaseLayer` property / status. This behaviour can be activated by initializing the `CpsiMapview.view.LayerTree` with the config `structureMode: 'BASELAYER_OVERLAY'`. This results in two folders "Base Layers and Layers" in the Tree-Ui :

![grafik](https://user-images.githubusercontent.com/1185547/49001988-91cab180-f15e-11e8-9f4e-6bf9fd341580.png)

All other settings for `structureMode` will preserve the previous behaviour with a flat layer list.

This also ensures that the properties `qtip` and `iconCls` of the layer configuration get applied to modify tree layout and behaviour. 

Depends on https://github.com/geoext/geoext3/pull/453.

Closes #58.