### PR TITLE
ContextMenu plugin for a layer in the LayerTree

### DIFF
--- a/app/plugin/TreeColumnContextMenu.js
+++ b/app/plugin/TreeColumnContextMenu.js
@@ -1,6 +1,6 @@
 /**
  * Plugin in order to show a ContextMenu for a layer in the LayerTree.
- * ContextMenu is opened on right-cliking a layer in the tree and shows all
+ * ContextMenu is opened on right-clicking a layer in the tree and shows all
  * configured menu items / tools.
  *
  * @class CpsiMapview.plugin.TreeColumnContextMenu
@@ -9,6 +9,13 @@ Ext.define('CpsiMapview.plugin.TreeColumnContextMenu', {
     extend: 'GeoExt.plugin.layertreenode.ContextMenu',
     alias: 'plugin.cmv_tree_column_context_menu',
     pluginId: 'cmv_tree_column_context_menu',
+
+    /**
+     * The 'xtypes' of the items, which will be shown in this context menu.
+     *
+     * @cfg {String[]}
+     */
+    menuItems: [],
 
     /**
      * @private

--- a/app/plugin/TreeColumnContextMenu.js
+++ b/app/plugin/TreeColumnContextMenu.js
@@ -1,0 +1,52 @@
+/**
+ * Plugin in order to show a ContextMenu for a layer in the LayerTree.
+ * ContextMenu is opened on right-cliking a layer in the tree and shows all
+ * configured menu items / tools.
+ *
+ * @class CpsiMapview.plugin.TreeColumnContextMenu
+ */
+Ext.define('CpsiMapview.plugin.TreeColumnContextMenu', {
+    extend: 'GeoExt.plugin.layertreenode.ContextMenu',
+    alias: 'plugin.cmv_tree_column_context_menu',
+    pluginId: 'cmv_tree_column_context_menu',
+
+    /**
+     * @private
+     */
+    init: function () {
+        this.callParent(arguments);
+    },
+
+    /**
+     * Implements the abstract #createContextUi of the father class in order to
+     * create a menu with all items accordinng to the corresponding layer
+     * properties, e.g. 'refreshLayerOption' to show an item to refresh / redraw
+     * the layer.
+     *
+     * @param  {GeoExt.data.model.LayerTreeNode} layerTreeNode
+     *     The LayerTreeNode of the right-clicked layer
+     * @return {Ext.menu.Menu} The menu holding all configured items / tools
+     */
+    createContextUi: function (layerTreeNode) {
+        var me = this;
+        var menuItems = [];
+
+        // create all menu items / tools
+        Ext.each(me.menuItems, function (menuItem) {
+            menuItems.push({
+                xtype: menuItem,
+                layer: layerTreeNode.getOlLayer()
+            });
+        });
+
+        // create the menu and hide if empty
+        var emptyMenu = menuItems.length === 0;
+        var menu = Ext.create('Ext.menu.Menu', {
+            items: menuItems,
+            hidden: emptyMenu
+        });
+
+        return menu;
+    }
+
+});


### PR DESCRIPTION
Adds a plugin in order to show a ContextMenu for a layer in the LayerTree.
This is done by overwriting / implementing the `GeoExt.plugin.layertreenode.ContextMenu`. Creates all  items configured in the `menuItems` config property. These have to be valid xtypes of a `Ext.menu.Item` or a derived component.

**CAUTION: This cannot be merged before https://github.com/geoext/geoext3/pull/501 is merged.**