### PR TITLE
Add "Refresh Layer" tool as item in layer context menu

### DIFF
--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -90,6 +90,9 @@ Ext.define('CpsiMapview.factory.Layer', {
             mapLayer.set('description', layerConf.qtip);
             // changes the icon in the layer tree leaf
             mapLayer.set('iconCls', layerConf.iconCls);
+            // indicator if a refresh option is offered in layer context menu
+            var allowRefresh = layerConf.refreshLayerOption !== false;
+            mapLayer.set('refreshLayerOption', allowRefresh);
         }
 
         return mapLayer;

--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -291,7 +291,8 @@ Ext.define('CpsiMapview.factory.Layer', {
             toolTipConfig: layerConf.tooltipsConfig,
             isTimeDependent: !!layerConf.timeitem,
             dateFormat: layerConf.dateFormat,
-            timeProperty: layerConf.timeitem
+            timeProperty: layerConf.timeitem,
+            isWfs: true
         };
         olLayerConf = Ext.apply(olLayerConf, olLayerProps);
 

--- a/app/plugin/TreeColumnContextMenu.js
+++ b/app/plugin/TreeColumnContextMenu.js
@@ -1,0 +1,52 @@
+/**
+ * Plugin in order to show a ContextMenu for a layer in the LayerTree.
+ * ContextMenu is opened on right-cliking a layer in the tree and shows all
+ * configured menu items / tools.
+ *
+ * @class CpsiMapview.plugin.TreeColumnContextMenu
+ */
+Ext.define('CpsiMapview.plugin.TreeColumnContextMenu', {
+    extend: 'GeoExt.plugin.layertreenode.ContextMenu',
+    alias: 'plugin.cmv_tree_column_context_menu',
+    pluginId: 'cmv_tree_column_context_menu',
+
+    /**
+     * @private
+     */
+    init: function () {
+        this.callParent(arguments);
+    },
+
+    /**
+     * Implements the abstract #createContextUi of the father class in order to
+     * create a menu with all items accordinng to the corresponding layer
+     * properties, e.g. 'refreshLayerOption' to show an item to refresh / redraw
+     * the layer.
+     *
+     * @param  {GeoExt.data.model.LayerTreeNode} layerTreeNode
+     *     The LayerTreeNode of the right-clicked layer
+     * @return {Ext.menu.Menu} The menu holding all configured items / tools
+     */
+    createContextUi: function (layerTreeNode) {
+        var me = this;
+        var menuItems = [];
+
+        // create all menu items / tools
+        Ext.each(me.menuItems, function (menuItem) {
+            menuItems.push({
+                xtype: menuItem,
+                layer: layerTreeNode.getOlLayer()
+            });
+        });
+
+        // create the menu and hide if empty
+        var emptyMenu = menuItems.length === 0;
+        var menu = Ext.create('Ext.menu.Menu', {
+            items: menuItems,
+            hidden: emptyMenu
+        });
+
+        return menu;
+    }
+
+});

--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -7,7 +7,9 @@ Ext.define('CpsiMapview.view.LayerTree', {
     requires: [
         'BasiGX.util.Map',
         'GeoExt.data.store.LayersTree',
-        'CpsiMapview.plugin.BasicTreeColumnLegends'
+        'CpsiMapview.plugin.BasicTreeColumnLegends',
+        'CpsiMapview.plugin.TreeColumnContextMenu',
+        'CpsiMapview.view.menuitem.LayerRefresh'
     ],
 
     viewModel: {
@@ -36,6 +38,11 @@ Ext.define('CpsiMapview.view.LayerTree', {
                 flex: 1,
                 plugins: [{
                     ptype: 'cmv_basic_tree_column_legend'
+                }, {
+                    ptype: 'cmv_tree_column_context_menu',
+                    menuItems: [
+                        'cmv_menuitem_layerrefresh'
+                    ]
                 }]
             }
         ]

--- a/app/view/menuitem/LayerRefresh.js
+++ b/app/view/menuitem/LayerRefresh.js
@@ -1,0 +1,64 @@
+/**
+ * MenuItem to force redraw of a layer.
+ *
+ * @class CpsiMapview.view.menuitem.LayerRefresh
+ */
+Ext.define('CpsiMapview.view.menuitem.LayerRefresh', {
+    extend: 'Ext.menu.Item',
+    xtype: 'cmv_menuitem_layerrefresh',
+    requires: [],
+
+    /**
+     * The connected layer for this item.
+     *
+     * @cfg {ol.layer.Base}
+     */
+    layer: null,
+
+    /**
+     * Text shown in this MenuItem
+     * @cfg {String}
+     */
+    text: 'Refresh',
+
+
+    /**
+     * @private
+     */
+    initComponent: function () {
+        var me = this;
+        var allowRefresh = false;
+
+        if (me.layer) {
+            allowRefresh = me.layer.get('refreshLayerOption');
+        }
+
+        me.handler = me.handlerFunc;
+
+        me.callParent();
+
+        me.setHidden(!allowRefresh);
+    },
+
+    /**
+     * Executed when this menu item is clicked.
+     * Forces redraw of the connected layer.
+     */
+    handlerFunc: function () {
+        var me = this;
+        var source = me.layer.getSource();
+
+        // mostly WMS layers
+        if (source.updateParams) {
+            var params = source.getParams();
+            params.noCache = new Date().getMilliseconds();
+            source.updateParams(params);
+            source.refresh();
+        }
+
+        // mostly WFS layers
+        if (source instanceof ol.source.Vector) {
+            source.clear();
+        }
+    }
+});

--- a/app/view/menuitem/LayerRefresh.js
+++ b/app/view/menuitem/LayerRefresh.js
@@ -54,11 +54,12 @@ Ext.define('CpsiMapview.view.menuitem.LayerRefresh', {
             params.noCache = new Date().getMilliseconds();
             source.updateParams(params);
             source.refresh();
-        }
-
-        // mostly WFS layers
-        if (source instanceof ol.source.Vector) {
+        } else if (me.layer.get('isWfs') === true) {
+            // for WFS trigger reload of source
             source.clear();
+        } else {
+            // only refresh for other layers and sources (to not loose data)
+            source.refresh();
         }
     }
 });


### PR DESCRIPTION
This adds a "Refresh Layer" tool as `MenuItem` in the `LayerTree`'s ContextMenu.

Closes #77