### PR TITLE
Add "Labels Layer" tool as item in layer context menu 

### DIFF
--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -93,6 +93,8 @@ Ext.define('CpsiMapview.factory.Layer', {
             // indicator if a refresh option is offered in layer context menu
             var allowRefresh = layerConf.refreshLayerOption !== false;
             mapLayer.set('refreshLayerOption', allowRefresh);
+            // indicator if a label option is drawn in layer context menu
+            mapLayer.set('labelClassName', layerConf.labelClassName);
         }
 
         return mapLayer;

--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -90,6 +90,9 @@ Ext.define('CpsiMapview.factory.Layer', {
             mapLayer.set('description', layerConf.qtip);
             // changes the icon in the layer tree leaf
             mapLayer.set('iconCls', layerConf.iconCls);
+            // indicator if a refresh option is offered in layer context menu
+            var allowRefresh = layerConf.refreshLayerOption !== false;
+            mapLayer.set('refreshLayerOption', allowRefresh);
         }
 
         return mapLayer;

--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -7,7 +7,9 @@ Ext.define('CpsiMapview.view.LayerTree', {
     requires: [
         'BasiGX.util.Map',
         'GeoExt.data.store.LayersTree',
-        'CpsiMapview.plugin.BasicTreeColumnLegends'
+        'CpsiMapview.plugin.BasicTreeColumnLegends',
+        'CpsiMapview.plugin.TreeColumnContextMenu',
+        'CpsiMapview.view.menuitem.LayerRefresh'
     ],
 
     viewModel: {
@@ -36,6 +38,11 @@ Ext.define('CpsiMapview.view.LayerTree', {
                 flex: 1,
                 plugins: [{
                     ptype: 'cmv_basic_tree_column_legend'
+                }, {
+                    ptype: 'cmv_tree_column_context_menu',
+                    menuItems: [
+                        'cmv_menuitem_layerrefresh'
+                    ]
                 }]
             }
         ]

--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -9,7 +9,8 @@ Ext.define('CpsiMapview.view.LayerTree', {
         'GeoExt.data.store.LayersTree',
         'CpsiMapview.plugin.BasicTreeColumnLegends',
         'CpsiMapview.plugin.TreeColumnContextMenu',
-        'CpsiMapview.view.menuitem.LayerRefresh'
+        'CpsiMapview.view.menuitem.LayerRefresh',
+        'CpsiMapview.view.menuitem.LayerLabels'
     ],
 
     viewModel: {
@@ -41,7 +42,8 @@ Ext.define('CpsiMapview.view.LayerTree', {
                 }, {
                     ptype: 'cmv_tree_column_context_menu',
                     menuItems: [
-                        'cmv_menuitem_layerrefresh'
+                        'cmv_menuitem_layerrefresh',
+                        'cmv_menuitem_layerlabels'
                     ]
                 }]
             }

--- a/app/view/menuitem/LayerLabels.js
+++ b/app/view/menuitem/LayerLabels.js
@@ -1,0 +1,122 @@
+/**
+ * MenuItem showing a checkbox in the layer context menu that allows
+ * a separate label layer to be displayed alongside the feature layer.
+ *
+ * @class CpsiMapview.view.menuitem.LayerLabels
+ */
+Ext.define('CpsiMapview.view.menuitem.LayerLabels', {
+    extend: 'Ext.menu.CheckItem',
+    xtype: 'cmv_menuitem_layerlabels',
+    requires: [],
+
+    /**
+     * The connected layer for this item.
+     * @cfg {ol.layer.Base}
+     */
+    layer: null,
+
+    /**
+     * Text shown in this MenuItem.
+     * @cfg {String}
+     */
+    text: 'Labels',
+
+    /**
+     * The style name for the labels layer.
+     * @property {String}
+     * @readonly
+     */
+    labelClassName: null,
+
+
+    /**
+     * @private
+     */
+    initComponent: function () {
+        var me = this;
+
+        // try to detect the 'labelClassName' property of a WMS layer
+        if (me.layer && (me.layer.getSource() instanceof ol.source.TileWMS ||
+            me.layer.getSource() instanceof ol.source.ImageWMS)) {
+            me.labelClassName = me.layer.get('labelClassName');
+        }
+
+        me.callParent();
+
+        me.setHidden(Ext.isEmpty(me.labelClassName));
+
+        me.on('afterrender', me.onAfterrender);
+        me.on('checkchange', me.onCheckChange);
+    },
+
+    /**
+     * Handles the 'afterrender' event of this menu item.
+     * Checks / unchecks box dependent on if labels are displayed.
+     *
+     * @param  {Ext.menu.CheckItem} checkItem The menu item itself
+     */
+    onAfterrender: function (checkItem) {
+        var me = this;
+        if (Ext.isEmpty(me.labelClassName)) {
+            return;
+        }
+        var wmsSource = me.layer.getSource();
+        var wmsParams = wmsSource.getParams();
+
+        if (wmsParams && !Ext.isEmpty(wmsParams.STYLES) &&
+            wmsParams.STYLES.indexOf(me.labelClassName) !== -1) {
+            checkItem.setChecked(true);
+        } else {
+            checkItem.setChecked(false);
+        }
+    },
+
+    /**
+     * Handles the 'checkchange' event of this menu item.
+     *
+     * @param  {Ext.menu.CheckItem} checkItem The menu item itself
+     * @param  {Boolean}            checked   Current checked state
+     */
+    onCheckChange: function (checkItem, checked) {
+        this.addStyleParameters(checked);
+    },
+
+    /**
+     * Add label styles to the layer on the map by adding a separate layer in
+     * WMS LAYERS param with custom style.
+     *
+     * @param  {Boolean} addLabel Add or remove the label layer
+     */
+    addStyleParameters: function (addLabel) {
+        var me = this;
+        var layer = me.layer;
+        var labelClassName = me.labelClassName;
+        var wmsSource = layer.getSource();
+        var wmsParams = wmsSource.getParams();
+        var layers = wmsParams.LAYERS || [];
+        var styles = wmsParams.STYLES || '';
+        var layerList = Ext.isArray(layers) ? layers : layers.split(',');
+        var stylesList = Ext.isArray(styles) ? styles : styles.split(',');
+
+        if (addLabel) {
+            if (layerList.length === 1) {
+                // add a duplicate of the layer
+                layerList.push(layerList[0]);
+                // apply the label style on the duplicated layer
+                stylesList.push(labelClassName);
+            }
+        } else {
+            // remove any duplicate layer names created by adding labels
+            layerList = Ext.Array.unique(layerList);
+            // remove any label styles
+            Ext.Array.remove(stylesList, labelClassName);
+        }
+
+        var newParams = {
+            LAYERS: layerList.join(','),
+            STYLES: stylesList.join(',')
+        };
+
+        wmsSource.updateParams(newParams);
+    }
+});

--- a/app/view/menuitem/LayerRefresh.js
+++ b/app/view/menuitem/LayerRefresh.js
@@ -1,0 +1,64 @@
+/**
+ * MenuItem to force redraw of a layer.
+ *
+ * @class CpsiMapview.view.menuitem.LayerRefresh
+ */
+Ext.define('CpsiMapview.view.menuitem.LayerRefresh', {
+    extend: 'Ext.menu.Item',
+    xtype: 'cmv_menuitem_layerrefresh',
+    requires: [],
+
+    /**
+     * The connected layer for this item.
+     *
+     * @cfg {ol.layer.Base}
+     */
+    layer: null,
+
+    /**
+     * Text shown in this MenuItem
+     * @cfg {String}
+     */
+    text: 'Refresh',
+
+
+    /**
+     * @private
+     */
+    initComponent: function () {
+        var me = this;
+        var allowRefresh = false;
+
+        if (me.layer) {
+            allowRefresh = me.layer.get('refreshLayerOption');
+        }
+
+        me.handler = me.handlerFunc;
+
+        me.callParent();
+
+        me.setHidden(!allowRefresh);
+    },
+
+    /**
+     * Executed when this menu item is clicked.
+     * Forces redraw of the connected layer.
+     */
+    handlerFunc: function () {
+        var me = this;
+        var source = me.layer.getSource();
+
+        // mostly WMS layers
+        if (source.updateParams) {
+            var params = source.getParams();
+            params.noCache = new Date().getMilliseconds();
+            source.updateParams(params);
+            source.refresh();
+        }
+
+        // mostly WFS layers
+        if (source instanceof ol.source.Vector) {
+            source.clear();
+        }
+    }
+});


### PR DESCRIPTION
This adds a "Labels Layer" tool as `MenuItem` in the LayerTree's `ContextMenu`.

Currently contains the changes of #83 since this is based on that and is not merged yet. Please ignore the changes of #83. Main class to review is  `app/view/menuitem/LayerLabels.js`

Closes #78 
