### PR TITLE
Fix sencha build

### DIFF
--- a/app.json
+++ b/app.json
@@ -33,8 +33,12 @@
      */
     "classpath": [
         "app",
-        "${toolkit.name}/src",
-        "./lib/geoext3/src",
+        "./lib/geoext3/src/component",
+        "./lib/geoext3/src/data",
+        "./lib/geoext3/src/mixin",
+        "./lib/geoext3/src/plugin",
+        "./lib/geoext3/src/state",
+        "./lib/geoext3/src/util",
         "./lib/BasiGX/src"
     ],
 


### PR DESCRIPTION
This fixes the the failing sencha build by ignoring the `form` directory of `geoext3` in the classpath definition.

Please review and test with `Sencha Cmd 6.2` @annarieger.