### PR TITLE
Add gazetteer components

### DIFF
--- a/app.json
+++ b/app.json
@@ -33,12 +33,8 @@
      */
     "classpath": [
         "app",
-        "./lib/geoext3/src/component",
-        "./lib/geoext3/src/data",
-        "./lib/geoext3/src/mixin",
-        "./lib/geoext3/src/plugin",
-        "./lib/geoext3/src/state",
-        "./lib/geoext3/src/util",
+        "./lib/geoext3/src",
+        "./lib/geoext3/classic",
         "./lib/BasiGX/src"
     ],
 

--- a/app/view/toolbar/MapTools.js
+++ b/app/view/toolbar/MapTools.js
@@ -5,13 +5,13 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
     extend: 'Ext.toolbar.Toolbar',
     xtype: 'cmv_maptools',
     requires: [
+        'GeoExt.form.field.GeocoderComboBox',
         'BasiGX.view.button.Measure',
         'BasiGX.view.button.ZoomIn',
         'BasiGX.view.button.ZoomOut',
         'BasiGX.view.button.ZoomToExtent',
         'BasiGX.view.button.History',
         'CpsiMapview.view.button.DigitizeButton',
-
         'CpsiMapview.model.button.MeasureButton',
         'CpsiMapview.controller.button.MeasureButtonController',
         'CpsiMapview.controller.MapController'
@@ -81,5 +81,20 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
             startDate: new Date(2014, 0, 1),
             endDate: new Date(2020, 11, 30)
         }
-    ]
+    ],
+
+    /**
+     * @private
+     */
+    initComponent: function () {
+        var me = this;
+        var map = BasiGX.util.Map.getMapComponent().map;
+
+        me.items.push({
+            xtype: 'gx_geocoder_combo',
+            map: map
+        });
+
+        me.callParent();
+    }
 });

--- a/app/view/toolbar/MapTools.js
+++ b/app/view/toolbar/MapTools.js
@@ -14,7 +14,8 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
         'CpsiMapview.view.button.DigitizeButton',
         'CpsiMapview.model.button.MeasureButton',
         'CpsiMapview.controller.button.MeasureButtonController',
-        'CpsiMapview.controller.MapController'
+        'CpsiMapview.controller.MapController',
+        'CpsiMapview.view.combo.Gazetteer'
     ],
 
     controller: 'cmv_map',
@@ -90,8 +91,19 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
         var me = this;
         var map = BasiGX.util.Map.getMapComponent().map;
 
+        // Nominatim based location search
         me.items.push({
             xtype: 'gx_geocoder_combo',
+            map: map
+        });
+
+        // custom CPSI gazetteer
+        me.items.push({
+            xtype: 'cmv_gazetteer_combo',
+            url: 'https://pmstipperarydev.compass.ie/WebServices/townland/gazetteer/',
+            proxyRootProperty: 'data',
+            displayValueMapping: 'name',
+            emptyText: 'Townland...',
             map: map
         });
 


### PR DESCRIPTION
This PR adds two gazetteer components:

  - a Nominatim based geocoding combobox from GeoExt
  - a custom CPSI gazetteer / geocoding combobox (extending the `GeocoderCombo` of GeoExt)

Closes #70