### PR TITLE
Do not show geocoding layers in LayerTree

### DIFF
--- a/app/view/combo/Gazetteer.js
+++ b/app/view/combo/Gazetteer.js
@@ -52,6 +52,10 @@ Ext.define('CpsiMapview.view.combo.Gazetteer', {
             me.getStore().getProxy().setUrl(url);
         });
 
+        me.on('afterrender', function () {
+            me.locationLayer.set('displayInLayerSwitcher', false);
+        });
+
         me.callParent();
     },
 

--- a/app/view/toolbar/MapTools.js
+++ b/app/view/toolbar/MapTools.js
@@ -94,7 +94,12 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
         // Nominatim based location search
         me.items.push({
             xtype: 'gx_geocoder_combo',
-            map: map
+            map: map,
+            listeners: {
+                afterrender: function (gcCombo) {
+                    gcCombo.locationLayer.set('displayInLayerSwitcher', false);
+                }
+            }
         });
 
         // custom CPSI gazetteer


### PR DESCRIPTION
Avoids showing the result layers of the geocoding / gazetteer comboboxes in the LayerTree.