### PR TITLE
Render SV panorama to body of floating window

### DIFF
--- a/app/controller/button/StreetViewTool.js
+++ b/app/controller/button/StreetViewTool.js
@@ -219,7 +219,8 @@ Ext.define('CpsiMapview.controller.button.StreetViewTool', {
                 autoShow: false,
                 listeners: {
                     afterrender: function (win) {
-                        me.svDiv = Ext.getDom(win.getId());
+                        // render SV panorama to body of the window
+                        me.svDiv = Ext.getDom(win.body);
                     },
                     destroy: function () {
                         me.unregisterGmapsEvents();


### PR DESCRIPTION
This PR ensures that the SV panorama is rendered to the body of the floating window. So the layout issue described in #71 gets fixed.